### PR TITLE
Fixed bug with multiple vars on the "ifchanged" statement.

### DIFF
--- a/lib/Haanga/Compiler.php
+++ b/lib/Haanga/Compiler.php
@@ -1253,7 +1253,7 @@ class Haanga_Compiler
                 ));
 
                 if (isset($expr)) {
-                    $this_expr = hexpr($expr, '&&', $this_expr);
+                    $this_expr = hexpr($expr, '||', $this_expr);
                 }
 
                 $expr = $this_expr;


### PR DESCRIPTION
According to the Django documentation, {% ifchanged var1 var2 %} generates an "ifchanged($var1) || ifchanged($var2)" statement.
