### PR TITLE
Add "linebreaksbr" filter (works as in Django)

### DIFF
--- a/lib/Haanga/Extension/Filter/Linebreaksbr.php
+++ b/lib/Haanga/Extension/Filter/Linebreaksbr.php
@@ -1,0 +1,10 @@
+<?php
+
+class Haanga_Extension_Filter_Linebreaksbr
+{
+    static function generator($compiler, $args)
+    {
+    	$compiler->var_is_safe = TRUE;			/* we assume that if you use |linebreaksbr, you also want |safe */
+        return hexec('preg_replace', "/\r\n|\r|\n/", "<br />\n", $args[0]);
+    }
+}

--- a/lib/Haanga/Loader.php
+++ b/lib/Haanga/Loader.php
@@ -30,6 +30,7 @@ spl_autoload_register(function ($class) {
   'haanga_extension_filter_default' => '/Extension/Filter/Default.php',
   'haanga_extension_filter_length' => '/Extension/Filter/Length.php',
   'haanga_extension_filter_truncatechars' => '/Extension/Filter/Truncatechars.php',
+  'haanga_extension_filter_linebreaksbr' => '/Extension/Filter/Linebreaksbr.php',
   'haanga_extension_filter_intval' => '/Extension/Filter/Intval.php',
   'haanga_extension_filter_translation' => '/Extension/Filter/Translation.php',
   'haanga_extension_filter_trans' => '/Extension/Filter/Trans.php',


### PR DESCRIPTION
I added the `linebreaksbr` filter because I needed it in a project. This filter replaces newlines with `<br />`, as in Django, which is quite useful for basic text. Feel free to pull if you find it useful. :)
