### PR TITLE
Remove duplicated Strlen filter

### DIFF
--- a/lib/Haanga/Extension/Filter/Strlen.php
+++ b/lib/Haanga/Extension/Filter/Strlen.php
@@ -1,7 +1,0 @@
-<?php
-
-class Haanga_Extension_Filter_Length
-{
-    public $php_alias = "strlen";
-    public $is_safe = TRUE; /* a number if safe */
-}


### PR DESCRIPTION
The filter was never intended to be used, because it is superseeded by the
Length filter and both have the same class name

The problem is that when installing Haanga with newer versions of composer
(1.0 and up) sometimes the filter that is loaded when using

Haanga_Extension_Filter_Length

is the one being removed in this patch that fails when it intends to
calculate the length of an array.
